### PR TITLE
Use correct GPT2 citation

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -87,7 +87,7 @@ We choose the \textbf{GPT2} model as one possibility to generate texts for testi
 	\item Discriminative fine-tuning on every specific task.
 \end{enumerate}
 
-To achieve effective transfer with minor changes to the model architecture, task-aware input is used during transformations. \cite{radford2019language}
+To achieve effective transfer with minor changes to the model architecture, task-aware input is used during transformations. \cite{radford2018improving}
 
 The \textbf{Falcon-RW-1B} model built by TII (\url{https://www.tii.ae/}) is the second text generative model we use to test our augmentation models. It is a decoder-only model trained on 350 billion tokens of the RefinedWeb data set. This data set leverages strict filtering and stringent deduplication to uplift the quality of web data. \cite{penedo2023refinedweb}
 

--- a/paper.tex
+++ b/paper.tex
@@ -80,14 +80,14 @@ The exact procedure how DALL-E models work proposed by Ramesh et. al is explaine
 
 We choose the \textbf{GPT2} model as one possibility to generate texts for testing our augmentation methods. The GPT model tries to counter the scarcity of labeled text data for machine learning.
 
-\cite{radford2018improving} try to avoid this problem in a simple two step procedure:
+\cite{radford2019language} try to avoid this problem in a simple two step procedure:
 
 \begin{enumerate}
 	\item A generative pre-training of a language model on a varying corpus of unlabeled text.
 	\item Discriminative fine-tuning on every specific task.
 \end{enumerate}
 
-To achieve effective transfer with minor changes to the model architecture, task-aware input is used during transformations. \cite{radford2018improving}
+To achieve effective transfer with minor changes to the model architecture, task-aware input is used during transformations. \cite{radford2019language}
 
 The \textbf{Falcon-RW-1B} model built by TII (\url{https://www.tii.ae/}) is the second text generative model we use to test our augmentation models. It is a decoder-only model trained on 350 billion tokens of the RefinedWeb data set. This data set leverages strict filtering and stringent deduplication to uplift the quality of web data. \cite{penedo2023refinedweb}
 


### PR DESCRIPTION
As we used a GPT2 model from https://huggingface.co/gpt2 we should also use the according paper to cite, as mentioned on the page.